### PR TITLE
update casa3.4-4.2 code

### DIFF
--- a/science-containers/Dockerfiles/casa/version-3.4-4.2/Dockerfile
+++ b/science-containers/Dockerfiles/casa/version-3.4-4.2/Dockerfile
@@ -10,7 +10,7 @@ FROM images.canfar.net/skaha/centos:5
 #ADD CentOS-Base.repo /etc/yum.repos.d/
 
 RUN yum clean all -y
-RUN yum makecache -y
+#RUN yum makecache -y
 RUN yum update -y
 
 #These are already included in the CANFAR base centos5 container

--- a/science-containers/Dockerfiles/casa/version-3.4-4.2/Dockerfile
+++ b/science-containers/Dockerfiles/casa/version-3.4-4.2/Dockerfile
@@ -1,20 +1,23 @@
-FROM centos:5
+FROM images.canfar.net/skaha/centos:5
+#NB: centos 5 repo no longer available directly from Docker
 
 # xterm dependency is an extra to get the casa shell in the display
 # perl was added for casa later than 5
 
+#coding below was needed when centos taken from source
 # Override old repo info with current urls
-RUN rm /etc/yum.repos.d/CentOS-Base.repo
-ADD CentOS-Base.repo /etc/yum.repos.d/
+#RUN rm /etc/yum.repos.d/CentOS-Base.repo
+#ADD CentOS-Base.repo /etc/yum.repos.d/
 
 RUN yum clean all -y
 RUN yum makecache -y
 RUN yum update -y
 
-RUN yum install -y freetype libSM libXi libXrender libXrandr \
-	libXfixes libXcursor libXinerama fontconfig \
-	libxslt xauth xorg-x11-server-Xvfb dbus-x11 \
-	tkinter ImageMagick-c++ xterm perl
+#These are already included in the CANFAR base centos5 container
+#RUN yum install -y freetype libSM libXi libXrender libXrandr \
+#	libXfixes libXcursor libXinerama fontconfig \
+#	libxslt xauth xorg-x11-server-Xvfb dbus-x11 \
+#	tkinter ImageMagick-c++ xterm perl
 
 # setup all required env variables
 ARG CASA_RELEASE
@@ -52,4 +55,15 @@ ADD nsswitch.conf /etc/
 
 RUN chmod -R a+rwx /skaha
 
-ENTRYPOINT [ "/skaha/startup.sh" ]
+#Add in analysisUtils package
+RUN mkdir /opt/casa/analysisUtils
+RUN yum install -y wget
+RUN cd /opt/casa/analysisUtils && wget ftp://ftp.cv.nrao.edu/pub/casaguides/analysis_scripts.tar && tar -xvf analysis_scripts.tar
+#(if above doesn't work, can manually download the package and add as below)
+#ADD ./analysis_scripts.tar /opt/casa/analysisUtils/
+#NB: the analysisUtils path is added to the CASA startup file in the init.sh script     
+# (needs access to user's $HOME)
+
+#HK updated below
+#ENTRYPOINT [ "/skaha/startup.sh" ]
+CMD [ "/skaha/init.sh" ]

--- a/science-containers/Dockerfiles/casa/version-3.4-4.2/Makefile
+++ b/science-containers/Dockerfiles/casa/version-3.4-4.2/Makefile
@@ -1,7 +1,9 @@
 # uses python2.6
+VERSIONSCASA3 = \
+#       34.0.19988-002-64b 
+
 VERSIONS2.6 = \
-	34.0.19988-002-64b \
-	40.0.22208-002-64b \
+#	40.0.22208-002-64b \
 	40.1.22889-003-64b \
 	41.0.24668-001-64b-2
 
@@ -12,17 +14,13 @@ VERSIONS = \
 	42.2.30986-1-64b \
 	42.2.30986-pipe-1-64b
 
-#VERSIONS2.6 = \
-#	34.0.19988-002-64b
 
-#VERSIONS = \
-#	42.2.30986-pipe-1-64b
-
-DOCKER_REPO_BASE=images.canfar.net/arcade/casa
+DOCKER_REPO_BASE=images.canfar.net/casa-4/casa
+DOCKER_REPO_BASE3=images.canfar.net/casa-3/casa
 
 .PHONY: build clean run 
 
-all: build2.6 build
+all: build2.6 build3 build
 
 build2.6: 
 	@- $(foreach V,$(VERSIONS2.6), \
@@ -30,6 +28,11 @@ build2.6:
 		docker build --build-arg CASA_RELEASE=casapy-$(V) --build-arg PYTHON=python2.6 -t ${DOCKER_REPO_BASE}:$(V) .; \
 	)
 
+build3: 
+	@- $(foreach V,$(VERSIONSCASA3), \
+		./download.sh casapy-$(V); \
+		docker build --build-arg CASA_RELEASE=casapy-$(V) --build-arg PYTHON=python2.6 -t ${DOCKER_REPO_BASE3}:$(V) .; \
+	)
 build: 
 	@- $(foreach V,$(VERSIONS), \
 		./download.sh casapy-$(V); \
@@ -39,6 +42,10 @@ build:
 clean2.6:
 	@- $(foreach V,$(VERSIONS2.6), \
 	  docker rmi ${DOCKER_REPO_BASE}:$(V) ; \
+	)
+clean3:
+	@- $(foreach V,$(VERSIONSCASA3), \
+	  docker rmi ${DOCKER_REPO_BASE3}:$(V) ; \
 	)
 
 clean:
@@ -52,10 +59,14 @@ upload2.6: build2.6
 	  docker push ${DOCKER_REPO_BASE}:$(V) ; \
 	)
 
+upload3: build3
+	@- $(foreach V,$(VERSIONSCASA3), \
+	  docker push ${DOCKER_REPO_BASE3}:$(V) ; \
+	)
 upload: build
 	@- $(foreach V,$(VERSIONS), \
 	  docker push ${DOCKER_REPO_BASE}:$(V) ; \
 	)
 
-clean_all: clean2.6 clean
-upload_all: upload2.6 upload
+clean_all: clean2.6 clean3 clean
+upload_all: upload2.6 upload3 upload


### PR DESCRIPTION
minor & long-overdue updates to coding to reflect currently build-able code:
- updated harbor directory structure where containers are pushed
- uses locally archived Centos5 base for stability
- adds common CASA package analysisUtils