### PR TITLE
Casa4.5-4.7

### DIFF
--- a/science-containers/Dockerfiles/casa/centos610/CentOS-Base.repo
+++ b/science-containers/Dockerfiles/casa/centos610/CentOS-Base.repo
@@ -1,0 +1,25 @@
+[base]
+name=CentOS-$releasever - Base
+# mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+# baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+baseurl=https://vault.centos.org/6.10/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+# released updates
+[updates]
+name=CentOS-$releasever - Updates
+# mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+# baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+baseurl=https://vault.centos.org/6.10/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+# additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+# mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
+# baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+baseurl=https://vault.centos.org/6.10/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/science-containers/Dockerfiles/casa/centos610/Dockerfile
+++ b/science-containers/Dockerfiles/casa/centos610/Dockerfile
@@ -1,0 +1,20 @@
+FROM centos:6.10
+#this Dockerfile runs through the build of a centos6 container and saves it
+# to images.canfar.net, to use as a base for the subsequent builds of older
+# casa versions, because the web-based centos6 distributions are becoming
+# unstable and unmaintained
+
+# Override old repo info with current urls
+RUN rm /etc/yum.repos.d/CentOS-Base.repo
+ADD CentOS-Base.repo /etc/yum.repos.d/
+
+RUN yum clean all -y
+RUN yum makecache -y
+RUN yum update -y
+RUN yum install -y freetype libSM libXi libXrender libXrandr \
+	libXfixes libXcursor libXinerama fontconfig \
+        libxslt xauth xorg-x11-server-Xvfb dbus-x11 \
+	tkinter ImageMagick-c++ xterm perl autoconf python-sphinx graphviz
+
+RUN yum install -y sssd-client acl
+

--- a/science-containers/Dockerfiles/casa/centos610/Makefile
+++ b/science-containers/Dockerfiles/casa/centos610/Makefile
@@ -1,0 +1,28 @@
+
+VERSIONS = \
+	6.10
+
+
+DOCKER_REPO_BASE=images.canfar.net/skaha/centos
+
+.PHONY: build clean run 
+
+all: build
+
+build: 
+	@- $(foreach V,$(VERSIONS), \
+		docker build -t ${DOCKER_REPO_BASE}:$(V) .; \
+    	)
+
+clean:
+	@- $(foreach V,$(VERSIONS), \
+	  docker rmi ${DOCKER_REPO_BASE}:$(V) ; \
+	)
+
+
+upload: build
+	@- $(foreach V,$(VERSIONS), \
+	  docker push ${DOCKER_REPO_BASE}:$(V) ; \
+	)
+clean_all: clean
+upload_all: upload

--- a/science-containers/Dockerfiles/casa/ubuntu20.04/Dockerfile
+++ b/science-containers/Dockerfiles/casa/ubuntu20.04/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:20.04
+
+#This Dockerfile creates a local version of the Ubuntu 20.04 OS, along with
+# standard software/libraries that CASA versions need to run.  This container
+# is stored on harbor for to assist with long term stability
+
+RUN apt update
+RUN apt upgrade -y
+
+RUN apt install -y libsm6 libxi6 libxrender1 libxrandr2 \
+        libxfixes3 libxcursor1 libxinerama1 fontconfig \
+        imagemagick xterm
+RUN apt install -y perl autoconf autoconf graphviz xz-utils \
+        gfortran libcanberra-gtk-module libsnl0
+#NB: for 20.04, need libsnl0 not libsnl-dev
+RUN apt install -y libxslt1.1 xauth xorg xvfb dbus
+
+RUN apt install -y libfuse2 
+
+#Add in firefox and library dependency
+RUN apt install -y firefox libpci3
+
+RUN apt install -y sssd acl
+

--- a/science-containers/Dockerfiles/casa/ubuntu20.04/Makefile
+++ b/science-containers/Dockerfiles/casa/ubuntu20.04/Makefile
@@ -1,0 +1,28 @@
+
+VERSIONS = \
+	20.04
+
+
+DOCKER_REPO_BASE=images.canfar.net/skaha/ubuntu
+
+.PHONY: build clean run 
+
+all: build
+
+build: 
+	@- $(foreach V,$(VERSIONS), \
+		docker build -t ${DOCKER_REPO_BASE}:$(V) .; \
+    	)
+
+clean:
+	@- $(foreach V,$(VERSIONS), \
+	  docker rmi ${DOCKER_REPO_BASE}:$(V) ; \
+	)
+
+
+upload: build
+	@- $(foreach V,$(VERSIONS), \
+	  docker push ${DOCKER_REPO_BASE}:$(V) ; \
+	)
+clean_all: clean
+upload_all: upload

--- a/science-containers/Dockerfiles/casa/ubuntu20.04/init.sh
+++ b/science-containers/Dockerfiles/casa/ubuntu20.04/init.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "INIT START"
+echo "sourcing admit_start.sh"
+source /opt/admit/admit_start.sh
+echo "setting up analysisUtils path"
+echo 'import sys' > $HOME/.casa/init.py
+echo 'sys.path.append("/opt/casa/analysisUtils/analysis_scripts/")' >> $HOME/.casa/init.py
+echo 'import analysisUtils as au' >> $HOME/.casa/init.py
+echo 'import analysisUtils as AU' >> $HOME/.casa/init.py
+echo "INIT DONE"

--- a/science-containers/Dockerfiles/casa/ubuntu20.04/nsswitch.conf
+++ b/science-containers/Dockerfiles/casa/ubuntu20.04/nsswitch.conf
@@ -1,0 +1,62 @@
+#
+# /etc/nsswitch.conf
+#
+# An example Name Service Switch config file. This file should be
+# sorted with the most-used services at the beginning.
+#
+# The entry '[NOTFOUND=return]' means that the search for an
+# entry should stop if the search in the previous entry turned
+# up nothing. Note that if the search failed due to some other reason
+# (like no NIS server responding) then the search continues with the
+# next entry.
+#
+# Valid entries include:
+#
+#	nisplus			Use NIS+ (NIS version 3)
+#	nis			Use NIS (NIS version 2), also called YP
+#	dns			Use DNS (Domain Name Service)
+#	files			Use the local files
+#	db			Use the local database (.db) files
+#	compat			Use NIS on compat mode
+#	hesiod			Use Hesiod for user lookups
+#	[NOTFOUND=return]	Stop searching if not found so far
+#
+
+# To use db, put the "db" in front of "files" for entries you want to be
+# looked up first in the databases
+#
+# Example:
+#passwd:    db files nisplus nis
+#shadow:    db files nisplus nis
+#group:     db files nisplus nis
+
+passwd:     sss files
+shadow:     files sss
+group:      sss files
+
+#hosts:     db files nisplus nis dns
+hosts:      files dns
+
+# Example - obey only what nisplus tells us...
+#services:   nisplus [NOTFOUND=return] files
+#networks:   nisplus [NOTFOUND=return] files
+#protocols:  nisplus [NOTFOUND=return] files
+#rpc:        nisplus [NOTFOUND=return] files
+#ethers:     nisplus [NOTFOUND=return] files
+#netmasks:   nisplus [NOTFOUND=return] files
+
+bootparams: nisplus [NOTFOUND=return] files
+
+ethers:     files
+netmasks:   files
+networks:   files
+protocols:  files
+rpc:        files
+services:   files
+
+netgroup:   nisplus
+
+publickey:  nisplus
+
+automount:  files nisplus
+aliases:    files nisplus

--- a/science-containers/Dockerfiles/casa/ubuntu20.04/update-data.patch
+++ b/science-containers/Dockerfiles/casa/ubuntu20.04/update-data.patch
@@ -1,0 +1,27 @@
+#!/usr/bin/perl
+##
+## move rsync point from svn.cv.nrao.edu to casa.nrao.edu
+##
+use File::Find;
+
+if ( scalar(@ARGV) < 1 ) { die "$0 requires path to CASA installation to be patched..." }
+if ( scalar(@ARGV) > 1 ) { die "$0 requires only one parameter which is the path to CASA installation to be patched..." }
+
+unless ( -d $ARGV[0] ) { die "$0 requires path to CASA installation (which should be a directory) to be patched..." }
+
+sub locate_script {
+    if ( -f $_ && $_ eq "update-data" ) {
+        print "substituting $File::Find::dir/$_\n";
+        open( CONTENTS, "< $_" );
+        my @contents = <CONTENTS>;
+        close( CONTENTS );
+        open( CONTENTS, "> $_" );
+        foreach my $x ( @contents ) {
+            $x =~ s@(?:rsync://svn.cv.nrao.edu/casa-data|rsync://casa.nrao.edu/casa-data)@rsync://casa-rsync.nrao.edu/casa-data@g;
+            print CONTENTS "$x";
+        }
+        close( CONTENTS );
+    }
+}
+
+find( { wanted => \&locate_script }, $ARGV[0] );

--- a/science-containers/Dockerfiles/casa/version-4.5-4.7/Dockerfile
+++ b/science-containers/Dockerfiles/casa/version-4.5-4.7/Dockerfile
@@ -1,0 +1,57 @@
+FROM images.canfar.net/skaha/centos:6
+
+#Upgraded to use base OS as centos6 as saved on harbor for stability
+#Split out from old 4.5-5.8 combined directory as casa5.x versions
+#Can have UVMultiFit installed, but casa4.X cannot
+
+# xterm dependency is an extra to get the casa shell in the display
+# perl was added for casa later than 5
+
+# setup all required env variables
+ARG CASA_RELEASE
+ENV CASA_RELEASE=${CASA_RELEASE}
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/casa/bin
+
+# untar casa databundle to container
+ADD ${CASA_RELEASE}.tar.gz /opt/
+
+# chown because the untarred casa has wrong owner/group
+RUN chown -R root:root /opt/${CASA_RELEASE} && ln -s /opt/${CASA_RELEASE} /opt/casa
+
+# add the admit enhancement (issue #25)
+RUN yum install -y tcsh
+RUN mkdir /opt/admit
+ADD admit /opt/admit
+RUN cd /opt/admit && \
+    autoconf && ./configure --with-casa-root=/opt/${CASA_RELEASE}
+
+# Allow runtime symlink creation to the casa-data-repository
+# Create a dangling symlink to casa-data-repository so that after deployment
+# the symlink will link to the actual casa-data-repository in storage.
+RUN mkdir -p /arc/projects/casa-data-repository
+RUN rm -rf /opt/${CASA_RELEASE}/data && \
+    ln -s /arc/projects/casa-data-repository/ /opt/${CASA_RELEASE}/data
+RUN chmod 777 /opt/${CASA_RELEASE}
+RUN rm -rf /arc
+
+
+RUN mkdir /skaha
+ADD init.sh /skaha/
+
+# generate missing dbus uuid (issue #47)
+RUN dbus-uuidgen --ensure
+
+ADD nsswitch.conf /etc/
+
+#Add in analysisUtils package
+RUN mkdir /opt/casa/analysisUtils 
+RUN yum install -y wget
+RUN cd /opt/casa/analysisUtils && wget ftp://ftp.cv.nrao.edu/pub/casaguides/analysis_scripts.tar && tar -xvf analysis_scripts.tar
+#(if above doesn't work, can manually download the package and add as below)
+#ADD ./analysis_scripts.tar /opt/casa/analysisUtils/
+#NB: the analysisUtils path is added to the CASA startup file in the init.sh script
+# (needs access to user's $HOME)
+
+RUN cd /opt/${CASA_RELEASE}
+
+CMD [ "/skaha/init.sh" ]

--- a/science-containers/Dockerfiles/casa/version-4.5-4.7/Makefile
+++ b/science-containers/Dockerfiles/casa/version-4.5-4.7/Makefile
@@ -1,0 +1,34 @@
+VERSIONS = \
+	4.5.0-el6 #\
+#	4.5.1-el6 \
+	4.5.2-el6 \
+	4.5.3-el6 \
+	4.6.0-el6 \
+	4.7.0-el6 \
+	4.7.1-el6 \
+	4.7.2-el6
+
+DOCKER_REPO_BASE=images.canfar.net/casa-4/casa
+
+.PHONY: build clean run 
+
+all: build
+build: 
+	@- $(foreach V,$(VERSIONS), \
+		./download.sh casa-release-$(V) current ; \
+		docker build --build-arg CASA_RELEASE=casa-release-$(V) -t ${DOCKER_REPO_BASE}:$(V) .; \
+	)
+
+clean:
+	@- $(foreach V,$(VERSIONS), \
+                docker rmi ${DOCKER_REPO_BASE}:$(V) ; \
+	)
+
+clean-all: clean 
+
+upload: build
+	@- $(foreach V,$(VERSIONS), \
+                docker push ${DOCKER_REPO_BASE}:$(V) ; \
+	)
+
+upload-all: upload 

--- a/science-containers/Dockerfiles/casa/version-4.5-4.7/download.sh
+++ b/science-containers/Dockerfiles/casa/version-4.5-4.7/download.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 2 ]
+then
+  echo "usage: $0 <version> <"old"|"current">"
+  exit 1
+fi
+
+RELEASE=$1
+FILE="${RELEASE}.tar.gz"
+
+if [ $2 == "old" ]; then
+  URL="https://casa.nrao.edu/download/distro/linux/release/el6/${FILE}"
+elif [ $2 == "pipeline" ]; then
+  URL="https://casa.nrao.edu/download/distro/casa-pipeline/release/el6/${FILE}"
+else
+  URL="https://casa.nrao.edu/download/distro/casa/release/el6/${FILE}"
+fi
+
+# make sure we are in the source folder
+HERE=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+cd $HERE
+
+if [ ! -e "$FILE" ]; then
+    curl -O  $URL
+else
+    echo "$FILE already downloaded."
+fi
+
+FILE="admit"
+URL="https://github.com/astroumd/${FILE}"
+if [ ! -e "$FILE" ]; then
+    git clone  $URL
+else
+    echo "$FILE already downloaded."
+fi

--- a/science-containers/Dockerfiles/casa/version-4.5-4.7/init.sh
+++ b/science-containers/Dockerfiles/casa/version-4.5-4.7/init.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "INIT START"
+echo "sourcing admit_start.sh"
+source /opt/admit/admit_start.sh
+echo "setting up analysisUtils path"
+echo 'import sys' > $HOME/.casa/init.py
+echo 'sys.path.append("/opt/casa/analysisUtils/analysis_scripts/")' >> $HOME/.casa/init.py
+echo 'import analysisUtils as au' >> $HOME/.casa/init.py
+echo 'import analysisUtils as AU' >> $HOME/.casa/init.py
+echo "INIT DONE"

--- a/science-containers/Dockerfiles/casa/version-4.5-4.7/nsswitch.conf
+++ b/science-containers/Dockerfiles/casa/version-4.5-4.7/nsswitch.conf
@@ -1,0 +1,62 @@
+#
+# /etc/nsswitch.conf
+#
+# An example Name Service Switch config file. This file should be
+# sorted with the most-used services at the beginning.
+#
+# The entry '[NOTFOUND=return]' means that the search for an
+# entry should stop if the search in the previous entry turned
+# up nothing. Note that if the search failed due to some other reason
+# (like no NIS server responding) then the search continues with the
+# next entry.
+#
+# Valid entries include:
+#
+#	nisplus			Use NIS+ (NIS version 3)
+#	nis			Use NIS (NIS version 2), also called YP
+#	dns			Use DNS (Domain Name Service)
+#	files			Use the local files
+#	db			Use the local database (.db) files
+#	compat			Use NIS on compat mode
+#	hesiod			Use Hesiod for user lookups
+#	[NOTFOUND=return]	Stop searching if not found so far
+#
+
+# To use db, put the "db" in front of "files" for entries you want to be
+# looked up first in the databases
+#
+# Example:
+#passwd:    db files nisplus nis
+#shadow:    db files nisplus nis
+#group:     db files nisplus nis
+
+passwd:     sss files
+shadow:     files sss
+group:      sss files
+
+#hosts:     db files nisplus nis dns
+hosts:      files dns
+
+# Example - obey only what nisplus tells us...
+#services:   nisplus [NOTFOUND=return] files
+#networks:   nisplus [NOTFOUND=return] files
+#protocols:  nisplus [NOTFOUND=return] files
+#rpc:        nisplus [NOTFOUND=return] files
+#ethers:     nisplus [NOTFOUND=return] files
+#netmasks:   nisplus [NOTFOUND=return] files
+
+bootparams: nisplus [NOTFOUND=return] files
+
+ethers:     files
+netmasks:   files
+networks:   files
+protocols:  files
+rpc:        files
+services:   files
+
+netgroup:   nisplus
+
+publickey:  nisplus
+
+automount:  files nisplus
+aliases:    files nisplus

--- a/science-containers/Dockerfiles/casa/version-4.5-4.7/update-data.patch
+++ b/science-containers/Dockerfiles/casa/version-4.5-4.7/update-data.patch
@@ -1,0 +1,27 @@
+#!/usr/bin/perl
+##
+## move rsync point from svn.cv.nrao.edu to casa.nrao.edu
+##
+use File::Find;
+
+if ( scalar(@ARGV) < 1 ) { die "$0 requires path to CASA installation to be patched..." }
+if ( scalar(@ARGV) > 1 ) { die "$0 requires only one parameter which is the path to CASA installation to be patched..." }
+
+unless ( -d $ARGV[0] ) { die "$0 requires path to CASA installation (which should be a directory) to be patched..." }
+
+sub locate_script {
+    if ( -f $_ && $_ eq "update-data" ) {
+        print "substituting $File::Find::dir/$_\n";
+        open( CONTENTS, "< $_" );
+        my @contents = <CONTENTS>;
+        close( CONTENTS );
+        open( CONTENTS, "> $_" );
+        foreach my $x ( @contents ) {
+            $x =~ s@(?:rsync://svn.cv.nrao.edu/casa-data|rsync://casa.nrao.edu/casa-data)@rsync://casa-rsync.nrao.edu/casa-data@g;
+            print CONTENTS "$x";
+        }
+        close( CONTENTS );
+    }
+}
+
+find( { wanted => \&locate_script }, $ARGV[0] );


### PR DESCRIPTION
Similar updates to 3.4-4.2 and 4.3-4.4:
- updated to centos6 container saved on harbor for long-term stability
- added analysisutils package

Additional change for here: this build directory is now split off from the old 4.5-5.8 to cover only CASA versions 4.5-4.7.  A new package, UVMultiFit, is being added to CASA5.X, but it is not compatible with CASA4.X