### PR TITLE
Firefly Container Support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/science-containers/Dockerfiles/firefly"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "America/Vancouver"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "firefly"
+      include: "scope"
+    ignore:
+      - dependency-name: "gradle:jdk21-*"
+    groups:
+      firefly:
+        patterns:
+          - "ipac/firefly"
+        update-types: ["major", "minor"]
+    labels:
+      - "dependencies"
+      - "docker"
+    pull-request-branch-name:
+      separator: "-"

--- a/.github/workflows/firefly.yml
+++ b/.github/workflows/firefly.yml
@@ -32,7 +32,7 @@ jobs:
         id: upstream
         run: |
           # Extract version from Dockerfile and validate format
-          version=$(grep '^FROM ipac/firefly:' Dockerfile \
+          version=$(grep '^FROM ipac/firefly:' science-containers/Dockerfiles/firefly/Dockerfile \
                | head -1 \
                | sed -E 's#^FROM ipac/firefly:(.+)$#\1#')
           

--- a/.github/workflows/firefly.yml
+++ b/.github/workflows/firefly.yml
@@ -1,0 +1,86 @@
+name: Build & Push Firefly
+
+on:
+  schedule:
+    # Run every week
+    - cron: '0 0 * * 0'
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+    paths:
+      - 'science-containers/Dockerfiles/firefly/**'
+      - '.github/workflows/firefly.yml'
+
+jobs:
+  build:
+    # Repository name-guard to prevent this workflow from running on forks
+    if: ${{ github.repository == 'opencadc/science-containers' }}
+    name: Build and Push Firefly
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write # Attest the build provenance
+      id-token: write # Generate OIDC token for attestations
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 1
+    
+      - name: Firefly Release Version
+        id: upstream
+        run: |
+          # Extract version from Dockerfile and validate format
+          version=$(grep '^FROM ipac/firefly:' Dockerfile \
+               | head -1 \
+               | sed -E 's#^FROM ipac/firefly:(.+)$#\1#')
+          
+          # Validate version format (e.g., 2025.2)
+          if ! [[ $version =~ ^[0-9]{4}\.[0-9]+$ ]]; then
+            echo "Error: Invalid version format: $version"
+            exit 1
+          fi
+          
+          echo "version=$version" >> $GITHUB_OUTPUT
+      
+      - name: Echo Version
+        run: |
+          echo "Building Firefly Version: ${{ steps.upstream.outputs.version }}"
+    
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.10.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3.4.0
+        with:
+          registry: images.canfar.net
+          username: ${{ secrets.CANFAR_HARBOR_ROBOT_PUBLISHER_USERNAME }}
+          password: ${{ secrets.CANFAR_HARBOR_ROBOT_PUBLISHER_SECRET }}
+      
+      - name: Build & Push Firefly
+        id: build
+        uses: docker/build-push-action@v6.16.0
+        with:
+          context: science-containers/Dockerfiles/firefly
+          file: science-containers/Dockerfiles/firefly/Dockerfile
+          push: true
+          tags: |
+            images.canfar.net/skaha/firefly:${{ steps.upstream.outputs.version }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+          labels: |
+            org.opencontainers.image.title=skaha/firefly
+            org.opencontainers.image.description='CADC Firefly'
+            org.opencontainers.image.version=${{ steps.upstream.outputs.version }}
+            org.opencontainers.image.source=https://github.com/opencadc/science-containers
+
+      - name: Attest Image
+        uses: actions/attest-build-provenance@v2.3.0
+        with:
+          subject-name: images.canfar.net/skaha/firefly
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/science-containers/Dockerfiles/firefly/Dockerfile
+++ b/science-containers/Dockerfiles/firefly/Dockerfile
@@ -1,9 +1,9 @@
-FROM gradle:jdk21 AS base
+FROM gradle:jdk21-alpine AS base
 
 COPY . /firefly
 WORKDIR /firefly/cadc-sso
 
-SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+SHELL ["/bin/sh", "-eo", "pipefail", "-c"]
 
 FROM base AS builder
 RUN set -eux; \
@@ -11,5 +11,5 @@ RUN set -eux; \
     && ls -l lib/build/libs/cadc-sso-*.jar
 
 # Currently, the CADC-SSO Adapter only works with the nightly build of Firefly
-FROM ipac/firefly:nightly
+FROM ipac/firefly:2025.2
 COPY --from=builder /firefly/cadc-sso/lib/build/libs/cadc-sso-*.jar /usr/local/tomcat/webapps-ref/firefly/WEB-INF/lib/


### PR DESCRIPTION
- Added dependabot to auto detect new docker images from upstream publication from ipac/firefly and trigger a Dockerfile update
- Added firefly build and publish action to build and push container images to `images.canfar.net`