### PR TITLE
Code to build CASA version 6.6.4.  

### DIFF
--- a/science-containers/Dockerfiles/casa/version-6.6.4/Dockerfile
+++ b/science-containers/Dockerfiles/casa/version-6.6.4/Dockerfile
@@ -1,0 +1,103 @@
+FROM images.canfar.net/skaha/ubuntu:22.04
+
+# setup all required env variables
+ARG CASA_RELEASE
+ENV CASA_RELEASE=${CASA_RELEASE}
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/casa/bin
+
+# unpack and move casa databundle to container
+ADD ${CASA_RELEASE}.tar.xz /opt/
+
+# chown because the untarred casa has wrong owner/group
+##NB: commands below revert back to the pre-CASA6.4 terminology, as the version of python AND el7 (etc) is now specified everywhere in the full path.
+##NB2: pipelines may be an exception. 
+## (the %%-py* string removes the -py3.X part of the CASA_RELEASE variable name for the directory structure)
+#RUN chown -R root:root /opt/${CASA_RELEASE%%-py*} && ln -s /opt/${CASA_RELEASE%%-py*} /opt/casa
+RUN chown -R root:root /opt/${CASA_RELEASE} && ln -s /opt/${CASA_RELEASE} /opt/casa
+
+#
+
+# Allow runtime symlink creation to the casa-data-repository
+# Create a dangling symlink to casa-data-repository so that after deployment
+# the symlink will link to the actual casa-data-repository in storage.
+RUN mkdir -p /arc/projects/casa-data-repository && \
+    rm -rf /opt/${CASA_RELEASE}/data && \
+    ln -s /arc/projects/casa-data-repository/ /opt/${CASA_RELEASE}/data && \
+    chmod 777 /opt/${CASA_RELEASE} && \
+    cd /opt/${CASA_RELEASE} && \
+    REPLACED_DATA=`find lib -name __data__` && \
+    chmod 777 ${REPLACED_DATA}/.. && \
+    rm -rf ${REPLACED_DATA} && \
+    ln -s /arc/projects/casa-data-repository/ /opt/${CASA_RELEASE}/${REPLACED_DATA} && \
+    rm -rf /arc
+#For CASA6.6.4+, must create a casa config file which links to the leapsecond database.
+COPY casasiteconfig.py /opt/casa
+
+#Add in analysisUtils package
+RUN mkdir /opt/casa/analysisUtils && \
+    cd /opt/casa/analysisUtils && wget ftp://ftp.cv.nrao.edu/pub/casaguides/analysis_scripts.tar && tar -xvf analysis_scripts.tar
+#(if above doesn't work, can manually download the package and add as below)
+#ADD ./analysis_scripts.tar /opt/casa/analysisUtils/
+#NB: the analysisUtils path is added to the CASA startup file in the init.sh script
+# (needs access to user's $HOME)
+
+##NEW for CASA6.*: explicitly add in astropy
+##Instructions here: https://casadocs.readthedocs.io/en/latest/notebooks/frequently-asked-questions.html
+RUN /opt/${CASA_RELEASE}/bin/pip3 install astropy && \
+#also add astroquery (astroquery.readthedocs.io/en/latest/)
+    /opt/${CASA_RELEASE}/bin/python3 -m pip install --pre astroquery[all] 
+#
+## add the admit enhancement (issue #25)
+#ADMIT now installed after astropy as uses some of the same libraries
+RUN apt-get update && apt install -y git && \
+   cd /opt && git clone https://github.com/astroumd/admit && \
+   cd /opt/admit && git checkout python3 && \
+   /opt/${CASA_RELEASE}/bin/pip3 install -e .
+### re-write the start-up file, since instructions want the user to manually edit some fields from the default file downloaded from git
+##first command starts the file afresh, subsequent ones add lines to it
+RUN cd /opt/admit && \
+	echo '#/bin/bash' > admit_start.sh.in  && \
+	echo 'export ADMIT=/opt/admit' >> admit_start.sh.in && \
+	echo 'export CASA_ROOT=/opt/'${CASA_RELEASE} >> admit_start.sh.in && \
+	echo 'if test "x$CASA_ROOT" = "x"; then' >> admit_start.sh.in && \
+	echo '    unset CASA_ROOT' >> admit_start.sh.in && \
+	echo '    export PATH=${ADMIT}/bin:${PATH}' >> admit_start.sh.in && \
+	echo 'else' >> admit_start.sh.in && \
+	echo '    # CASA_ROOT has been deprecated as a bin by CASA' >> admit_start.sh.in && \
+	echo '    export PATH=${ADMIT}/bin:${CASA_ROOT}/bin:${CASA_ROOT}/lib/casa/bin:${CASA_ROOT}/:${PATH}' >> admit_start.sh.in && \
+	echo '    export TCL_LIBRARY=${CASA_ROOT}/share/tcl' >> admit_start.sh.in && \
+	echo '    export TK_LIBRARY=${CASA_ROOT}/share/tk' >> admit_start.sh.in && \
+	echo '    export LD_LIBRARY_PATH=${CASA_ROOT}/lib:${LD_LIBRARY_PATH}' >>admit_start.sh.in && \
+	echo 'fi' >> admit_start.sh.in && \
+	echo 'export CASA_PATH="$CASA_ROOT linux admit `hostname`"' >> admit_start.sh.in && \
+	echo 'export PYTHONPATH=${ADMIT}:${PYTHONPATH}' >> admit_start.sh.in && \
+	echo 'ln -s /bin/python3 /bin/python' >> admit_start.sh.in && \ 
+	bash /opt/admit/admit_start.sh.in
+#(HK added last line of admit_start.sh.in to avoid an error message about 'python not found' when running admit otherwise
+#HK modified last command from recommended 'source' to 'bash' for it to work here.  ('source' works when logging into the terminal for testing, but not in the build script)
+
+#Earlier versions of CASA can install ADMIT using the lines below instead
+#RUN mkdir /opt/admit
+#ADD admit /opt/admit
+#RUN cd /opt/admit && \
+#    autoconf && ./configure --with-casa-root=/opt/${CASA_RELEASE}
+
+
+RUN mkdir /skaha
+ADD init.sh /skaha/
+
+# generate missing dbus uuid (issue #47)
+RUN dbus-uuidgen --ensure
+
+ADD nsswitch.conf /etc/
+
+WORKDIR /opt
+COPY extract-casaviewer.sh .
+#below suggested by Seb to help with viewer script & variables, doesn't work
+# here for some reason, and generally hasn't been effective
+#ENV PYTHONPATH /opt/${CASA_RELEASE%%-py*}/lib/py/lib/python3.8/site-packages
+RUN bash extract-casaviewer.sh && rm extract-casaviewer.sh
+
+RUN chmod 777 -R /opt/squashfs-root /opt/squashfs-root/usr /opt/squashfs-root/usr/*
+
+CMD [ "/skaha/init.sh" ]

--- a/science-containers/Dockerfiles/casa/version-6.6.4/Makefile
+++ b/science-containers/Dockerfiles/casa/version-6.6.4/Makefile
@@ -1,0 +1,57 @@
+# NB: before using, uncomment the version to be built
+# NB2: One manual edit is also required in the extract_casaviewer.sh script,
+# about halfway down, to again select the command associated with setting up
+# plotms for the desired version of CASA
+
+
+VERSIONS_PIPELINE = \
+#	casa-6.1.1-15-pipeline-2020.1.0.40
+
+#!NB >casa6.5.6 versions have a different directory naming structure again
+VERSIONS = \
+	casa-6.6.4-34-py3.8.el7
+#	casa-6.6.3-22-py3.8.el7 
+#	casa-6.6.0-20-py3.8.el7
+#	casa-6.5.6-22-py3.8.el7
+
+DOCKER_REPO_BASE=images.canfar.net/casa-6/casa
+
+.PHONY: build clean run 
+
+all: build-pipeline build
+
+build-pipeline: 
+	@- $(foreach V,$(VERSIONS_PIPELINE), \
+                ./download.sh $(V) pipeline ; \
+                docker build --build-arg CASA_RELEASE=$(V) -t ${DOCKER_REPO_BASE}:$(V) .; \
+	)
+
+build: 
+	@- $(foreach V,$(VERSIONS), \
+                ./download.sh $(V) current ; \
+                docker build --build-arg CASA_RELEASE=$(V) -t ${DOCKER_REPO_BASE}:$(V) .; \
+	)
+
+clean-pipeline:
+	@- $(foreach V,$(VERSIONS_PIPELINE), \
+                docker rmi ${DOCKER_REPO_BASE}:$(V) ; \
+	)
+
+clean:
+	@- $(foreach V,$(VERSIONS), \
+                docker rmi ${DOCKER_REPO_BASE}:$(V) ; \
+	)
+
+clean-all: clean-old clean-pipeline clean 
+
+upload-pipeline: build-pipeline
+	@- $(foreach V,$(VERSIONS_PIPELINE), \
+                docker push ${DOCKER_REPO_BASE}:$(V) ; \
+	)
+
+upload: build
+	@- $(foreach V,$(VERSIONS), \
+                docker push ${DOCKER_REPO_BASE}:$(V) ; \
+	)
+
+upload-all: upload-pipeline upload 

--- a/science-containers/Dockerfiles/casa/version-6.6.4/casasiteconfig.py
+++ b/science-containers/Dockerfiles/casa/version-6.6.4/casasiteconfig.py
@@ -1,0 +1,12 @@
+#This is a CASA site configuration file for versions 6.6.4 or higher
+#Used to point casa to location of CASA run-time data such as the leapsecond
+# table, which for CANFAR is in a central site location
+#This config file should ideally be located at /opt/casa/casasiteconfig.py
+
+measurespath = "/arc/projects/casa-data-repository/"
+#(note that current documentation suggests a final directory of either /data
+# or /casarundata but neither of these directories are included in the
+# data directory which we are rsync-ing from NRAO )
+#turn off autoupdates b/c this is done by site staff not the user
+measures_auto_update = False
+data_auto_update = False

--- a/science-containers/Dockerfiles/casa/version-6.6.4/download.sh
+++ b/science-containers/Dockerfiles/casa/version-6.6.4/download.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 2 ]
+then
+  echo "usage: $0 <version> <"old"|"current">"
+  exit 1
+fi
+
+RELEASE=$1
+FILE="${RELEASE}.tar.xz"
+
+if [ $2 == "old" ]; then
+  URL="https://casa.nrao.edu/download/distro/casa/release/rhel//${FILE}"
+elif [ $2 == "pipeline" ]; then
+  URL="https://casa.nrao.edu/download/distro/casa-pipeline/release/linux/${FILE}"
+else
+  URL="https://casa.nrao.edu/download/distro/casa/release/rhel/${FILE}"
+fi
+
+# make sure we are in the source folder
+HERE=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+cd $HERE
+
+if [ ! -e "$FILE" ]; then
+    curl -O  $URL
+else
+    echo "$FILE already downloaded."
+fi
+
+FILE="admit"
+URL="https://github.com/astroumd/${FILE}"
+if [ ! -e "$FILE" ]; then
+    git clone  $URL
+else
+    echo "$FILE already downloaded."
+fi

--- a/science-containers/Dockerfiles/casa/version-6.6.4/extract-casaviewer.sh
+++ b/science-containers/Dockerfiles/casa/version-6.6.4/extract-casaviewer.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#NB: needs to be edited for casa version in first coding line below
+# AppImage fix applies now too casaviewer, casaplotms
+# and new: casalogger, casaplotserver, casatablebrowser, casafeather
+
+#casavers=casa-6.5.3-28-pipeline-2023.0.0.36
+#casavers=casa-6.4.1-12-pipeline-2022.2.0.64
+#casavers=casa-6.2.1-7-pipeline-2021.2.0.128
+#casavers=casa-6.1.1-15-pipeline-2020.1.0.40
+#casavers=casa-6.3.0-48
+#casavers=casa-6.2.0-124
+#casavers=casa-6.1.0-118
+#casavers=casa-6.4.0-16
+#casavers=casa-6.4.3-27
+#casavers=casa-6.5.6-22-py3.8.el7
+#casavers=casa-6.6.0-20-py3.8.el7
+#casavers=casa-6.6.3-22-py3.8.el7
+casavers=casa-6.6.4-34-py3.8.el7
+
+pyvers=python3.8
+#pyvers=python3.6
+elvers=el7 #new for latest versions
+
+pushd /opt
+#below command was original way of structuring this, but not working anymore
+#manually inputting casavers above to get around this
+#casaviewer=$(python3 -m casaviewer --app-path 2> /dev/null | grep casaviewer)
+#echo ${casaviewer}
+casaviewer=/opt/${casavers}/lib/py/lib/${pyvers}/site-packages/casaviewer/__bin__/casaviewer-x86_64.AppImage
+${casaviewer} --appimage-extract 2> /dev/null
+
+mv /opt/casa/bin/casaviewer /opt/casa/bin/casaviewer.old
+ln -s /opt/squashfs-root/AppRun /opt/casa/bin/casaviewer
+
+#additional steps courtesy of CASA helpdesk
+#NB: casa6.5 and higher use python3.8, only option
+mv /opt/casa/lib/py/lib/${pyvers}/site-packages/casaviewer/__bin__/casaviewer-x86_64.AppImage /opt/casa/lib/py/lib/${pyvers}/site-packages/casaviewer/__bin__/casaviewer-x86_64.AppImage.orig
+ln -s /opt/squashfs-root/usr/bin/casaviewer /opt/casa/lib/py/lib/${pyvers}/site-packages/casaviewer/__bin__/casaviewer-x86_64.AppImage
+
+#Apply similar process for other packages
+#1) extract AppImage
+/opt/${casavers}/lib/py/lib/${pyvers}/site-packages/casaplotms/__bin__/casaplotms-x86_64.AppImage --appimage-extract 2> /dev/null
+/opt/${casavers}/lib/py/lib/${pyvers}/site-packages/casalogger/__bin__/casalogger-x86_64.AppImage --appimage-extract 2> /dev/null
+/opt/${casavers}/lib/py/lib/${pyvers}/site-packages/casafeather/__bin__/casafeather-x86_64.AppImage --appimage-extract 2> /dev/null
+/opt/${casavers}/lib/py/lib/${pyvers}/site-packages/casaplotserver/__bin__/casaplotserver-x86_64.AppImage --appimage-extract 2> /dev/null
+/opt/${casavers}/lib/py/lib/${pyvers}/site-packages/casatablebrowser/__bin__/casatablebrowser-x86_64.AppImage --appimage-extract 2> /dev/null
+
+#2a) move old AppImage
+mv /opt/casa/lib/py/lib/${pyvers}/site-packages/casaplotms/__bin__/casaplotms-x86_64.AppImage /opt/casa/lib/py/lib/${pyvers}/site-packages/casaplotms/__bin__/casaplotms-x86_64.AppImage.orig
+mv /opt/casa/lib/py/lib/${pyvers}/site-packages/casalogger/__bin__/casalogger-x86_64.AppImage /opt/casa/lib/py/lib/${pyvers}/site-packages/casalogger/__bin__/casalogger-x86_64.AppImage.orig
+mv /opt/casa/lib/py/lib/${pyvers}/site-packages/casafeather/__bin__/casafeather-x86_64.AppImage /opt/casa/lib/py/lib/${pyvers}/site-packages/casafeather/__bin__/casafeather-x86_64.AppImage.orig
+mv /opt/casa/lib/py/lib/${pyvers}/site-packages/casaplotserver/__bin__/casaplotserver-x86_64.AppImage /opt/casa/lib/py/lib/${pyvers}/site-packages/casaplotserver/__bin__/casaplotserver-x86_64.AppImage.orig
+mv /opt/casa/lib/py/lib/${pyvers}/site-packages/casatablebrowser/__bin__/casatablebrowser-x86_64.AppImage /opt/casa/lib/py/lib/${pyvers}/site-packages/casatablebrowser/__bin__/casatablebrowser-x86_64.AppImage.orig
+
+#2b) link to new one
+ln -s /opt/squashfs-root/usr/bin/casaplotms /opt/casa/lib/py/lib/${pyvers}/site-packages/casaplotms/__bin__/casaplotms-x86_64.AppImage
+ln -s /opt/squashfs-root/usr/bin/casalogger /opt/casa/lib/py/lib/${pyvers}/site-packages/casalogger/__bin__/casalogger-x86_64.AppImage
+ln -s /opt/squashfs-root/usr/bin/casafeather /opt/casa/lib/py/lib/${pyvers}/site-packages/casafeather/__bin__/casafeather-x86_64.AppImage
+ln -s /opt/squashfs-root/usr/bin/casaplotserver /opt/casa/lib/py/lib/${pyvers}/site-packages/casaplotserver/__bin__/casaplotserver-x86_64.AppImage
+ln -s /opt/squashfs-root/usr/bin/casatablebrowser /opt/casa/lib/py/lib/${pyvers}/site-packages/casatablebrowser/__bin__/casatablebrowser-x86_64.AppImage
+
+
+popd

--- a/science-containers/Dockerfiles/casa/version-6.6.4/init.sh
+++ b/science-containers/Dockerfiles/casa/version-6.6.4/init.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "INIT START"
+echo "sourcing admit_start.sh"
+source /opt/admit/admit_start.sh
+echo "setting up analysisUtils path"
+echo 'import sys' > $HOME/.casa/startup.py
+echo 'sys.path.append("/opt/casa/analysisUtils/analysis_scripts/")' >> $HOME/.casa/startup.py
+echo 'import analysisUtils as au' >> $HOME/.casa/startup.py
+echo 'import analysisUtils as AU' >> $HOME/.casa/startup.py
+echo "INIT DONE"
+echo "INIT DONE"

--- a/science-containers/Dockerfiles/casa/version-6.6.4/nsswitch.conf
+++ b/science-containers/Dockerfiles/casa/version-6.6.4/nsswitch.conf
@@ -1,0 +1,62 @@
+#
+# /etc/nsswitch.conf
+#
+# An example Name Service Switch config file. This file should be
+# sorted with the most-used services at the beginning.
+#
+# The entry '[NOTFOUND=return]' means that the search for an
+# entry should stop if the search in the previous entry turned
+# up nothing. Note that if the search failed due to some other reason
+# (like no NIS server responding) then the search continues with the
+# next entry.
+#
+# Valid entries include:
+#
+#	nisplus			Use NIS+ (NIS version 3)
+#	nis			Use NIS (NIS version 2), also called YP
+#	dns			Use DNS (Domain Name Service)
+#	files			Use the local files
+#	db			Use the local database (.db) files
+#	compat			Use NIS on compat mode
+#	hesiod			Use Hesiod for user lookups
+#	[NOTFOUND=return]	Stop searching if not found so far
+#
+
+# To use db, put the "db" in front of "files" for entries you want to be
+# looked up first in the databases
+#
+# Example:
+#passwd:    db files nisplus nis
+#shadow:    db files nisplus nis
+#group:     db files nisplus nis
+
+passwd:     sss files
+shadow:     files sss
+group:      sss files
+
+#hosts:     db files nisplus nis dns
+hosts:      files dns
+
+# Example - obey only what nisplus tells us...
+#services:   nisplus [NOTFOUND=return] files
+#networks:   nisplus [NOTFOUND=return] files
+#protocols:  nisplus [NOTFOUND=return] files
+#rpc:        nisplus [NOTFOUND=return] files
+#ethers:     nisplus [NOTFOUND=return] files
+#netmasks:   nisplus [NOTFOUND=return] files
+
+bootparams: nisplus [NOTFOUND=return] files
+
+ethers:     files
+netmasks:   files
+networks:   files
+protocols:  files
+rpc:        files
+services:   files
+
+netgroup:   nisplus
+
+publickey:  nisplus
+
+automount:  files nisplus
+aliases:    files nisplus

--- a/science-containers/Dockerfiles/casa/version-6.6.4/update-data.patch
+++ b/science-containers/Dockerfiles/casa/version-6.6.4/update-data.patch
@@ -1,0 +1,27 @@
+#!/usr/bin/perl
+##
+## move rsync point from svn.cv.nrao.edu to casa.nrao.edu
+##
+use File::Find;
+
+if ( scalar(@ARGV) < 1 ) { die "$0 requires path to CASA installation to be patched..." }
+if ( scalar(@ARGV) > 1 ) { die "$0 requires only one parameter which is the path to CASA installation to be patched..." }
+
+unless ( -d $ARGV[0] ) { die "$0 requires path to CASA installation (which should be a directory) to be patched..." }
+
+sub locate_script {
+    if ( -f $_ && $_ eq "update-data" ) {
+        print "substituting $File::Find::dir/$_\n";
+        open( CONTENTS, "< $_" );
+        my @contents = <CONTENTS>;
+        close( CONTENTS );
+        open( CONTENTS, "> $_" );
+        foreach my $x ( @contents ) {
+            $x =~ s@(?:rsync://svn.cv.nrao.edu/casa-data|rsync://casa.nrao.edu/casa-data)@rsync://casa-rsync.nrao.edu/casa-data@g;
+            print CONTENTS "$x";
+        }
+        close( CONTENTS );
+    }
+}
+
+find( { wanted => \&locate_script }, $ARGV[0] );


### PR DESCRIPTION
Similar to the 6.6.1-pipeline request.  Includes a new way of installing ADMIT and a new way to point to the leapsecond database.