### PR TITLE
feat(carta-psrecord): Skaha env-driven startup + psrecord profiling

### DIFF
--- a/docs/user-guide/interactive-sessions/launch-carta.md
+++ b/docs/user-guide/interactive-sessions/launch-carta.md
@@ -32,7 +32,7 @@ then select **carta** as your session type.
 Note that the menu options update automatically after your session type selection. 
 Choose the CARTA version that meets your needs:
 
-- **CARTA 4.0** (recommended): Latest features and bug fixes
+- **CARTA 5.1.0** (recommended): Latest features and bug fixes
 (The screenshot is old and showed older versions only.)
 > ![image](../images/carta/2_select_carta_container.png)
 

--- a/docs/user-guide/radio-astronomy/index.md
+++ b/docs/user-guide/radio-astronomy/index.md
@@ -125,7 +125,7 @@ images.canfar.net/skaha/casa:6.5-notebook
 images.canfar.net/skaha/casa:6.5-desktop
 
 # CARTA for visualization
-images.canfar.net/skaha/carta:3.0
+images.canfar.net/skaha/carta:5.1.0
 
 # Custom radio astronomy stack
 images.canfar.net/skaha/radio-submm:latest
@@ -250,7 +250,7 @@ impv(
 
 CARTA excels at visualizing radio data cubes:
 
-1. **Launch CARTA session**: Use CARTA 3.0 for best performance
+1. **Launch CARTA session**: Use CARTA 5.1.0 for best performance
 2. **Load cube**: Open your CASA image or FITS cube
 3. **Navigate channels**: Use channel slider for frequency/velocity
 4. **Create animations**: Generate movies through the cube

--- a/science-containers/Dockerfiles/carta-psrecord/Dockerfile
+++ b/science-containers/Dockerfiles/carta-psrecord/Dockerfile
@@ -18,6 +18,11 @@ RUN chmod -R a+rwx /carta
 ENV HOME=/carta
 ENV CARTA_DOCKER_DEPLOYMENT=1
 
+# Optional: set at build (`--build-arg`) or runtime (`-e`) so psrecord uses `--duration` and exits without relying on a manual session stop.
+# Example timed diagnostics build: --build-arg PSRECORD_DURATION_SECONDS=600
+ARG PSRECORD_DURATION_SECONDS=
+ENV PSRECORD_DURATION_SECONDS=${PSRECORD_DURATION_SECONDS}
+
 COPY start.sh /carta/start.sh
 RUN chmod +x /carta/start.sh
 

--- a/science-containers/Dockerfiles/carta-psrecord/Dockerfile
+++ b/science-containers/Dockerfiles/carta-psrecord/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:24.04
+
+RUN apt update && \
+    apt install -y software-properties-common && \
+    add-apt-repository ppa:cartavis-team/carta && \
+    apt update && \
+    apt install -y carta python3-pip
+
+RUN pip3 install --break-system-packages psrecord matplotlib
+
+RUN mkdir /carta
+WORKDIR /carta
+
+EXPOSE 3002
+
+RUN chmod -R a+rwx /carta
+
+ENV HOME=/carta
+ENV CARTA_DOCKER_DEPLOYMENT=1
+
+COPY start.sh /carta/start.sh
+RUN chmod +x /carta/start.sh
+
+CMD ["/carta/start.sh"]

--- a/science-containers/Dockerfiles/carta-psrecord/README.md
+++ b/science-containers/Dockerfiles/carta-psrecord/README.md
@@ -1,0 +1,36 @@
+# skaha-carta-psrecord
+
+## About
+
+A CARTA 5.1.0 session container for skaha with resource profiling via [psrecord](https://github.com/astrofrog/psrecord). On session exit, CPU, memory, and I/O usage logs and plots are written to `~/.carta_logs/`.
+
+This is a companion container to `skaha/carta` intended for performance diagnostics. For regular use, prefer `skaha/carta`.
+
+## Resource Profiling Output
+
+Logs and plots are written to `~/.carta_logs/` on session exit:
+
+- `<timestamp>_carta-backend.log` — CPU, memory, and I/O usage over time
+- `<timestamp>_carta-backend.png` — Plot of the above
+
+## Building and Publishing
+
+skaha images are managed in the CANFAR image registry at https://images.canfar.net
+
+In order to push images to this registry, you need to be a publishing member of one of the projects, in this case `skaha`.  Since it is a private registry, you must login via `docker login` with what is called the harbor `CLI Secret` (Command Line Interface Secret).  The steps to do so are as follows:
+
+1. Login to https://images.canfar.net/ with your CADC Userid/Password by pressing the `LOGIN VIA OIDC PROVIDER` button.
+1. When prompted by harbor to enter an identification, type your CADC Userid or another name by which you wish to be known within the harbor registry.
+1. Copy your CLI Secret to your clipboard under the `User Profile` menu item in the top right corner of the Harbor portal.
+1. Log docker into harbor: `docker login images.canfar.net`.  Use the CLI Secret when prompted for a password.
+1. Build and push the image:
+
+```
+docker buildx build \
+  --platform linux/amd64 \
+  -t images.canfar.net/skaha/carta:5.1.0-psrecord \
+  . \
+  --push
+```
+
+After pushing, add the `carta` label to the image in the Harbor portal under `skaha/carta` to make it visible in the CANFAR science platform.

--- a/science-containers/Dockerfiles/carta-psrecord/README.md
+++ b/science-containers/Dockerfiles/carta-psrecord/README.md
@@ -13,6 +13,23 @@ Logs and plots are written to `~/.carta_logs/` on session exit:
 - `<timestamp>_carta-backend.log` — CPU, memory, and I/O usage over time
 - `<timestamp>_carta-backend.png` — Plot of the above
 
+### Timed diagnostics (`psrecord --duration`)
+
+If the Skaha session does not run this image’s `CMD` (so `start.sh` never executes), you will not get `.carta_logs/` output; that is independent of duration.
+
+When `start.sh` does run, you can force `psrecord` to stop after a fixed number of seconds so log/plot are written without manually ending the session:
+
+- **Runtime:** `PSRECORD_DURATION_SECONDS=600` (example: 600 = 10 minutes).
+- **Build-time:** pass `--build-arg PSRECORD_DURATION_SECONDS=600` so the value is baked into the image.
+
+Example local run (macOS/Linux, map a folder with FITS as read-only data):
+
+```
+docker run --rm -e PSRECORD_DURATION_SECONDS=120 -p 3002:3002 -v "$HOME/carta-data:/data:ro" images.canfar.net/skaha/carta:5.1.0-psrecord
+```
+
+Adjust the published host port to match the port CARTA prints in the container logs.
+
 ## Building and Publishing
 
 skaha images are managed in the CANFAR image registry at https://images.canfar.net
@@ -32,5 +49,7 @@ docker buildx build \
   . \
   --push
 ```
+
+To bake in a fixed duration (e.g. 600 seconds) for diagnostics, add `--build-arg PSRECORD_DURATION_SECONDS=600` and use a distinct tag (example: `5.1.0-psrecord-timed`).
 
 After pushing, add the `carta` label to the image in the Harbor portal under `skaha/carta` to make it visible in the CANFAR science platform.

--- a/science-containers/Dockerfiles/carta-psrecord/README.md
+++ b/science-containers/Dockerfiles/carta-psrecord/README.md
@@ -45,7 +45,7 @@ In order to push images to this registry, you need to be a publishing member of 
 ```
 docker buildx build \
   --platform linux/amd64 \
-  -t images.canfar.net/skaha/carta:5.1.0-psrecord \
+  --tag images.canfar.net/skaha/carta:5.1.0-psrecord \
   . \
   --push
 ```

--- a/science-containers/Dockerfiles/carta-psrecord/start.sh
+++ b/science-containers/Dockerfiles/carta-psrecord/start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+dtm=$(date +%Y%m%d%H%M%S)
+logdir="${HOME}/.carta_logs"
+mkdir -p "${logdir}"
+
+psrecord "carta --no_browser" \
+    --log "${logdir}/${dtm}_carta-backend.log" \
+    --plot "${logdir}/${dtm}_carta-backend.png" \
+    --include-io \
+    --interval 1 \
+    --include-children

--- a/science-containers/Dockerfiles/carta-psrecord/start.sh
+++ b/science-containers/Dockerfiles/carta-psrecord/start.sh
@@ -1,12 +1,50 @@
 #!/bin/bash
+set -euo pipefail
 
 dtm=$(date +%Y%m%d%H%M%S)
 logdir="${HOME}/.carta_logs"
 mkdir -p "${logdir}"
 
-psrecord "carta --no_browser" \
-    --log "${logdir}/${dtm}_carta-backend.log" \
-    --plot "${logdir}/${dtm}_carta-backend.png" \
-    --include-io \
-    --interval 1 \
-    --include-children
+# Default command works for local docker runs.
+# When Skaha env vars are provided, align with platform launch flags.
+carta_cmd=(carta --no_browser)
+if [ -n "${SKAHA_TOP_LEVEL_DIR:-}" ] || [ -n "${SKAHA_PROJECTS_DIR:-}" ] || [ -n "${SKAHA_SESSION_URL_PATH:-}" ]; then
+  top_dir="${SKAHA_TOP_LEVEL_DIR:-/arc}"
+  start_dir="${SKAHA_PROJECTS_DIR:-/arc/projects}"
+  carta_port="${CARTA_PORT:-6901}"
+  idle_timeout="${CARTA_IDLE_TIMEOUT:-100000}"
+
+  carta_cmd+=(
+    "--top_level_folder=${top_dir}"
+    "--enable_scripting"
+    "--port=${carta_port}"
+    "--idle_timeout=${idle_timeout}"
+    "--debug_no_auth"
+  )
+  if [ -n "${SKAHA_SESSION_URL_PATH:-}" ]; then
+    carta_cmd+=("--http_url_prefix=${SKAHA_SESSION_URL_PATH}")
+  fi
+  carta_cmd+=("${start_dir}")
+fi
+
+command_str="$(printf '%q ' "${carta_cmd[@]}")"
+command_str="${command_str% }"
+echo "start.sh: command=${command_str}"
+
+duration_args=()
+if [ -n "${PSRECORD_DURATION_SECONDS:-}" ]; then
+  if ! [[ "${PSRECORD_DURATION_SECONDS}" =~ ^[0-9]+$ ]] || [ "${PSRECORD_DURATION_SECONDS}" -eq 0 ]; then
+    echo "start.sh: PSRECORD_DURATION_SECONDS must be a positive integer (got: ${PSRECORD_DURATION_SECONDS})" >&2
+    exit 1
+  fi
+  duration_args=(--duration "${PSRECORD_DURATION_SECONDS}")
+  echo "start.sh: psrecord will stop after ${PSRECORD_DURATION_SECONDS}s (then write log/plot under ${logdir})" >&2
+fi
+
+psrecord "${command_str}" \
+  --log "${logdir}/${dtm}_carta-backend.log" \
+  --plot "${logdir}/${dtm}_carta-backend.png" \
+  --include-io \
+  --interval 1 \
+  --include-children \
+  "${duration_args[@]}"

--- a/science-containers/Dockerfiles/carta/README.md
+++ b/science-containers/Dockerfiles/carta/README.md
@@ -19,7 +19,7 @@ In order to push images to this registry, you need to be a publishing member of 
 ```
 docker buildx build \
   --platform linux/amd64 \
-  -t images.canfar.net/skaha/carta:5.1.0 \
+  --tag images.canfar.net/skaha/carta:5.1.0 \
   . \
   --push
 ```

--- a/science-containers/Dockerfiles/carta/README.md
+++ b/science-containers/Dockerfiles/carta/README.md
@@ -2,24 +2,26 @@
 
 ## About
 
-A CARTA 5.0 session container for skaha based on CARTA-remote (https://github.com/CARTAvis).
+A CARTA 5.1.0 session container for skaha based on CARTA-remote (https://github.com/CARTAvis).
 
-A wrapper script, `skaha-carta`, is added to the container that calls the CARTA binary `carta`.
-
-## Building
-
-```
-docker build -t images.canfar.net/skaha/carta:5.0 -f Dockerfile .
-```
-
-## Publishing to the image registry
+## Building and Publishing
 
 skaha images are managed in the CANFAR image registry at https://images.canfar.net
 
-In order to push images to this registry, you need to be a publishing member of one of the projects, in this case cirada.  Since it is a private registry, you must login via `docker login` with what is called the harbor `CLI Secret` (Command Line Interface Secret).  The steps to do so are as follows:
+In order to push images to this registry, you need to be a publishing member of one of the projects, in this case `skaha`.  Since it is a private registry, you must login via `docker login` with what is called the harbor `CLI Secret` (Command Line Interface Secret).  The steps to do so are as follows:
 
 1. Login to https://images.canfar.net/ with your CADC Userid/Password by pressing the `LOGIN VIA OIDC PROVIDER` button.
 1. When prompted by harbor to enter an identification, type your CADC Userid or another name by which you wish to be known within the harbor registry.
 1. Copy your CLI Secret to your clipboard under the `User Profile` menu item in the top right corner of the Harbor portal.
-1. Log docker into harbor by typing `docker login <CADC Userid>`.  Use the CLI Secret in your clipboard when prompted for a password.
-1. Push the image to harbor:  `docker push images.canfar.net/carta/skaha-carta:5.0`
+1. Log docker into harbor: `docker login images.canfar.net`.  Use the CLI Secret when prompted for a password.
+1. Build and push the image:
+
+```
+docker buildx build \
+  --platform linux/amd64 \
+  -t images.canfar.net/skaha/carta:5.1.0 \
+  . \
+  --push
+```
+
+After pushing, add the `carta` label to the image in the Harbor portal under `skaha/carta` to make it visible in the CANFAR science platform.

--- a/science-containers/Dockerfiles/globus/.dockerignore
+++ b/science-containers/Dockerfiles/globus/.dockerignore
@@ -17,9 +17,6 @@
 .env.*
 *.local
 
-# Claude
-.claude
-
 # OS files
 .DS_Store
 Thumbs.db

--- a/science-containers/Dockerfiles/globus/.gitignore
+++ b/science-containers/Dockerfiles/globus/.gitignore
@@ -5,9 +5,6 @@
 *.swo
 *~
 
-# Claude Code
-.claude/
-
 # OS files
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
- Update version from 5.0 to 5.1.0
- Remove outdated skaha-carta wrapper script reference
- Replace separate build/push steps with single buildx command
- Fix image path from carta/skaha-carta to skaha/carta
- Add note about Harbor label requirement