### PR TITLE
fix(carta): launch via skaha env startup script

### DIFF
--- a/science-containers/Dockerfiles/carta-psrecord/Dockerfile
+++ b/science-containers/Dockerfiles/carta-psrecord/Dockerfile
@@ -11,7 +11,7 @@ RUN pip3 install --break-system-packages psrecord matplotlib
 RUN mkdir /carta
 WORKDIR /carta
 
-EXPOSE 3002
+EXPOSE 6901
 
 RUN chmod -R a+rwx /carta
 

--- a/science-containers/Dockerfiles/carta/Dockerfile
+++ b/science-containers/Dockerfiles/carta/Dockerfile
@@ -9,11 +9,14 @@ RUN apt update && \
 RUN mkdir /carta
 WORKDIR /carta
 
-EXPOSE 3002
+EXPOSE 6901
 
 RUN chmod -R a+rwx /carta
 
 ENV HOME=/carta
 ENV CARTA_DOCKER_DEPLOYMENT=1
 
-CMD ["carta", "--no_browser"]
+COPY start.sh /carta/start.sh
+RUN chmod +x /carta/start.sh
+
+CMD ["/carta/start.sh"]

--- a/science-containers/Dockerfiles/carta/start.sh
+++ b/science-containers/Dockerfiles/carta/start.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-dtm=$(date +%Y%m%d%H%M%S)
-logdir="${HOME}/.carta_logs"
-mkdir -p "${logdir}"
-
 # Default command works for local docker runs.
 # When Skaha env vars are provided, align with platform launch flags.
 carta_cmd=(carta --no_browser)
@@ -32,20 +28,4 @@ command_str="$(printf '%q ' "${carta_cmd[@]}")"
 command_str="${command_str% }"
 echo "start.sh: command=${command_str}"
 
-duration_args=()
-if [ -n "${PSRECORD_DURATION_SECONDS:-}" ]; then
-  if ! [[ "${PSRECORD_DURATION_SECONDS}" =~ ^[0-9]+$ ]] || [ "${PSRECORD_DURATION_SECONDS}" -eq 0 ]; then
-    echo "start.sh: PSRECORD_DURATION_SECONDS must be a positive integer (got: ${PSRECORD_DURATION_SECONDS})" >&2
-    exit 1
-  fi
-  duration_args=(--duration "${PSRECORD_DURATION_SECONDS}")
-  echo "start.sh: psrecord will stop after ${PSRECORD_DURATION_SECONDS}s (then write log/plot under ${logdir})" >&2
-fi
-
-psrecord "${command_str}" \
-  --log "${logdir}/${dtm}_carta-backend.log" \
-  --plot "${logdir}/${dtm}_carta-backend.png" \
-  --include-io \
-  --interval 1 \
-  --include-children \
-  "${duration_args[@]}"
+exec "${carta_cmd[@]}"


### PR DESCRIPTION
This change was already reviewed and approved in my fork PR, but was accidentally merged it into my fork’s `main` instead of opening the PR against upstream.

Opening this PR now to merge the same approved CARTA startup-script change into `opencadc/science-containers`.

For validation purpose, please refer to the commit histories.
