### PR TITLE
Support last carta version

### DIFF
--- a/science-containers/Dockerfiles/carta/Dockerfile
+++ b/science-containers/Dockerfiles/carta/Dockerfile
@@ -4,17 +4,25 @@ ARG CARTA_VERSION=5.1.0
 ENV CARTA_VERSION=${CARTA_VERSION}
 
 RUN apt update && \
-    apt install -y wget libfuse2t64 && \
+    apt install -y wget && \
     rm -rf /var/lib/apt/lists/*
 
+# Extract the AppImage at build time so FUSE is not required at runtime (e.g. Kubernetes).
 RUN mkdir -p "/opt/carta/${CARTA_VERSION}" && \
     wget -q "https://github.com/CARTAvis/carta/releases/download/v${CARTA_VERSION}/carta.AppImage.x86_64.tgz" \
       -O /tmp/carta.AppImage.tgz && \
     tar -xzf /tmp/carta.AppImage.tgz -C "/opt/carta/${CARTA_VERSION}" && \
-    chmod +x "/opt/carta/${CARTA_VERSION}/carta-x86_64.AppImage" && \
-    rm /tmp/carta.AppImage.tgz
+    cd "/opt/carta/${CARTA_VERSION}" && \
+    chmod +x carta-x86_64.AppImage && \
+    ./carta-x86_64.AppImage --appimage-extract && \
+    if [ ! -e squashfs-root/AppRun ] && [ -e squashfs-root/usr/bin/carta ]; then \
+      ln -s usr/bin/carta squashfs-root/AppRun; \
+    fi && \
+    mv squashfs-root app && \
+    chmod -R a+rx app && \
+    rm carta-x86_64.AppImage /tmp/carta.AppImage.tgz
 
-ENV CARTA_APP="/opt/carta/${CARTA_VERSION}/carta-x86_64.AppImage"
+ENV CARTA_APP="/opt/carta/${CARTA_VERSION}/app/AppRun"
 
 RUN mkdir /carta
 WORKDIR /carta

--- a/science-containers/Dockerfiles/carta/Dockerfile
+++ b/science-containers/Dockerfiles/carta/Dockerfile
@@ -1,10 +1,20 @@
 FROM ubuntu:24.04
 
+ARG CARTA_VERSION=5.1.0
+ENV CARTA_VERSION=${CARTA_VERSION}
+
 RUN apt update && \
-    apt install -y software-properties-common && \
-    add-apt-repository ppa:cartavis-team/carta && \
-    apt update && \
-    apt install -y carta
+    apt install -y wget libfuse2t64 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p "/opt/carta/${CARTA_VERSION}" && \
+    wget -q "https://github.com/CARTAvis/carta/releases/download/v${CARTA_VERSION}/carta.AppImage.x86_64.tgz" \
+      -O /tmp/carta.AppImage.tgz && \
+    tar -xzf /tmp/carta.AppImage.tgz -C "/opt/carta/${CARTA_VERSION}" && \
+    chmod +x "/opt/carta/${CARTA_VERSION}/carta-x86_64.AppImage" && \
+    rm /tmp/carta.AppImage.tgz
+
+ENV CARTA_APP="/opt/carta/${CARTA_VERSION}/carta-x86_64.AppImage"
 
 RUN mkdir /carta
 WORKDIR /carta

--- a/science-containers/Dockerfiles/carta/Dockerfile
+++ b/science-containers/Dockerfiles/carta/Dockerfile
@@ -4,7 +4,7 @@ ARG CARTA_VERSION=5.1.0
 ENV CARTA_VERSION=${CARTA_VERSION}
 
 RUN apt update && \
-    apt install -y wget && \
+    apt install -y libcurl4t64 wget && \
     rm -rf /var/lib/apt/lists/*
 
 # Extract the AppImage at build time so FUSE is not required at runtime (e.g. Kubernetes).

--- a/science-containers/Dockerfiles/carta/README.md
+++ b/science-containers/Dockerfiles/carta/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-A CARTA session container for skaha based on the official [CARTA AppImage](https://github.com/CARTAvis/carta/releases). Supported versions are built as separate image tags via the `CARTA_VERSION` build argument.
+A CARTA session container for skaha based on the official [CARTA AppImage](https://github.com/CARTAvis/carta/releases). The AppImage is extracted at build time so FUSE is not required at runtime in Kubernetes. Supported versions are built as separate image tags via the `CARTA_VERSION` build argument.
 
 ## Building and Publishing
 

--- a/science-containers/Dockerfiles/carta/README.md
+++ b/science-containers/Dockerfiles/carta/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-A CARTA 5.1.0 session container for skaha based on CARTA-remote (https://github.com/CARTAvis).
+A CARTA session container for skaha based on the official [CARTA AppImage](https://github.com/CARTAvis/carta/releases). Supported versions are built as separate image tags via the `CARTA_VERSION` build argument.
 
 ## Building and Publishing
 
@@ -14,14 +14,22 @@ In order to push images to this registry, you need to be a publishing member of 
 1. When prompted by harbor to enter an identification, type your CADC Userid or another name by which you wish to be known within the harbor registry.
 1. Copy your CLI Secret to your clipboard under the `User Profile` menu item in the top right corner of the Harbor portal.
 1. Log docker into harbor: `docker login images.canfar.net`.  Use the CLI Secret when prompted for a password.
-1. Build and push the image:
+1. Build and push each supported version:
 
 ```
 docker buildx build \
   --platform linux/amd64 \
+  --build-arg CARTA_VERSION=5.1.0 \
   --tag images.canfar.net/skaha/carta:5.1.0 \
+  . \
+  --push
+
+docker buildx build \
+  --platform linux/amd64 \
+  --build-arg CARTA_VERSION=5.0.3 \
+  --tag images.canfar.net/skaha/carta:5.0.3 \
   . \
   --push
 ```
 
-After pushing, add the `carta` label to the image in the Harbor portal under `skaha/carta` to make it visible in the CANFAR science platform.
+After pushing, add the `carta` label to each image in the Harbor portal under `skaha/carta` to make it visible in the CANFAR science platform.

--- a/science-containers/Dockerfiles/carta/start.sh
+++ b/science-containers/Dockerfiles/carta/start.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 # Default command works for local docker runs.
 # When Skaha env vars are provided, align with platform launch flags.
-carta_cmd=(carta --no_browser)
+carta_bin="${CARTA_APP:?CARTA_APP is not set}"
+carta_cmd=("${carta_bin}" --no_browser)
 if [ -n "${SKAHA_TOP_LEVEL_DIR:-}" ] || [ -n "${SKAHA_PROJECTS_DIR:-}" ] || [ -n "${SKAHA_SESSION_URL_PATH:-}" ]; then
   top_dir="${SKAHA_TOP_LEVEL_DIR:-/arc}"
   start_dir="${SKAHA_PROJECTS_DIR:-/arc/projects}"


### PR DESCRIPTION
Uses GitHub AppImage to install a wider variety of versions of CARTA.  This is currently used to support both the latest (5.1.0) and 5.0.3.
https://appimage.github.io/CARTA/